### PR TITLE
feat: yank marks to clipboard - hand your sticky notes to your AI assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ https://github.com/user-attachments/assets/4ebcb70b-0be8-4668-8a65-2eb5c950aec4
 - 🔍 **Telescope integration** - Search and navigate through all your sticky notes
 - ⚡ **Fast navigation** - Jump between sticky notes quickly
 - 📋 **Quickfix list support** - View all sticky notes in a quickfix list
+- 📎 **Yank to clipboard** - Copy sticky notes (path, line, note) to paste into AI chats or anywhere else
 
 ## 📦 Installation
 
@@ -126,6 +127,17 @@ require("fusen").setup()  -- Add options here if needed
       next_mark = "mn",       -- Jump to next mark
       prev_mark = "mp",       -- Jump to previous mark
       list_marks = "ml",      -- Show marks in quickfix
+      yank_line = "my",       -- Yank mark at cursor line to clipboard
+      yank_buffer = "mY",     -- Yank marks in current buffer to clipboard
+      yank_all = "mA",        -- Yank all marks in project to clipboard
+    },
+
+    -- Yank to clipboard settings
+    yank = {
+      -- Template for each mark. Placeholders: {path} {file} {line} {annotation}
+      template = '- @{path}:L{line} - "{annotation}"',
+      -- Used instead when the mark has no annotation
+      template_no_annotation = "- @{path}:L{line}",
     },
 
     -- Toggle mark settings
@@ -220,6 +232,9 @@ All default mappings start with `m` prefix for consistency:
 | `mn` | Jump to next sticky note |
 | `mp` | Jump to previous sticky note |
 | `ml` | List all sticky notes in quickfix |
+| `my` | Yank sticky note at cursor line to clipboard |
+| `mY` | Yank sticky notes in current buffer to clipboard |
+| `mA` | Yank all sticky notes in project to clipboard |
 
 ### Commands
 
@@ -233,6 +248,7 @@ All default mappings start with `m` prefix for consistency:
 | `:FusenNext` | Jump to next mark |
 | `:FusenPrev` | Jump to previous mark |
 | `:FusenList` | Show all marks in quickfix list |
+| `:FusenYank [line\|buffer\|all]` | Yank marks to clipboard (default: `line`) |
 | `:FusenRefresh` | Refresh all marks display |
 | `:FusenSave` | Manually save marks |
 | `:FusenLoad` | Manually load marks |
@@ -242,6 +258,49 @@ All default mappings start with `m` prefix for consistency:
 | `:FusenEnable` | Enable Fusen plugin (show marks and annotations) |
 | `:FusenDisable` | Disable Fusen plugin (hide all marks and annotations) |
 | `:FusenToggle` | Toggle Fusen on/off |
+
+### Yank to Clipboard
+
+Copy your sticky notes to the system clipboard (`+` register) and paste them anywhere — AI chats, issues, code review comments, etc.
+
+> **Note:** This requires a clipboard provider (see `:help clipboard`). macOS works out of the box; on Linux install `xclip`, `xsel` or `wl-clipboard`. Without a provider, a warning is shown and nothing is copied.
+
+```
+:FusenYank          " Mark at cursor line (same as `my`)
+:FusenYank buffer   " Marks in current buffer (same as `mY`)
+:FusenYank all      " All marks in project (same as `mA`)
+```
+
+Each mark is formatted with a customizable template:
+
+```lua
+-- Using lazy.nvim
+{
+  "walkersumida/fusen.nvim",
+  opts = {
+    yank = {
+      template = '- @{path}:L{line} - "{annotation}"',
+      template_no_annotation = "- @{path}:L{line}",
+    },
+  }
+}
+```
+
+Available placeholders:
+
+| Placeholder | Description |
+|-------------|-------------|
+| `{path}` | File path relative to the current working directory |
+| `{file}` | Absolute file path |
+| `{line}` | Line number |
+| `{annotation}` | Sticky note text |
+
+With the default template, the copied text looks like:
+
+```
+- @lua/fusen/init.lua:L42 - "TODO: refactor this function"
+- @lua/fusen/ui.lua:L15 - "This layout breaks on narrow windows"
+```
 
 ### Telescope Integration
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ https://github.com/user-attachments/assets/4ebcb70b-0be8-4668-8a65-2eb5c950aec4
 
 <table>
   <tr>
+    <th>Handing sticky notes to your AI assistant</th>
+  </tr>
+  <tr>
+    <td>
+      <img src="https://github.com/user-attachments/assets/5b3d005e-8e3d-4121-be9a-18bb6037bde9" />
+    </td>
+  </tr>
+  <tr>
     <th>Adding/Editing an annotation</th>
   </tr>
   <tr>
@@ -38,6 +46,7 @@ https://github.com/user-attachments/assets/4ebcb70b-0be8-4668-8a65-2eb5c950aec4
 
 ## ✨ Features
 
+- 🤖 **AI-friendly yank** - Hand all your sticky notes to AI assistants (Claude Code, Copilot CLI, etc.) in one keystroke
 - 📝 **Simple sticky notes** - Clean and minimalist sticky note system
 - 🌳 **Git branch awareness** - Sticky notes are stored per git branch
 - 💾 **Persistent storage** - Your sticky notes are saved between sessions
@@ -46,7 +55,6 @@ https://github.com/user-attachments/assets/4ebcb70b-0be8-4668-8a65-2eb5c950aec4
 - 🔍 **Telescope integration** - Search and navigate through all your sticky notes
 - ⚡ **Fast navigation** - Jump between sticky notes quickly
 - 📋 **Quickfix list support** - View all sticky notes in a quickfix list
-- 📎 **Yank to clipboard** - Copy sticky notes (path, line, note) to paste into AI chats or anywhere else
 
 ## 📦 Installation
 

--- a/doc/fusen.txt
+++ b/doc/fusen.txt
@@ -27,6 +27,7 @@ Key features:
 - Telescope integration for searching
 - Fast navigation between bookmarks
 - Quickfix list support
+- Yank marks to clipboard with customizable templates
 
 ==============================================================================
 INSTALLATION                                                   *fusen-install*
@@ -80,6 +81,14 @@ Default configuration: >lua
         next_mark = "mn",
         prev_mark = "mp",
         list_marks = "ml",
+        yank_line = "my",
+        yank_buffer = "mY",
+        yank_all = "mA",
+      },
+
+      yank = {
+        template = '- @{path}:L{line} - "{annotation}"',
+        template_no_annotation = "- @{path}:L{line}",
       },
 
       toggle_mark = {
@@ -165,6 +174,22 @@ Configuration options:
     special buffers where you don't want Fusen keymaps to be active.
     Examples: "neo-tree", "NvimTree", "nerdtree"
 
+`yank`                                                           *fusen-opt-yank*
+    Settings for yanking marks to the clipboard.
+
+    `template`                                          *fusen-opt-yank-template*
+        Template applied to each mark. Available placeholders:
+        - {path}: file path relative to the current working directory
+        - {file}: absolute file path
+        - {line}: line number
+        - {annotation}: sticky note text
+        Unknown placeholders are kept as-is.
+        Default: `- @{path}:L{line} - "{annotation}"`
+
+    `template_no_annotation`              *fusen-opt-yank-template_no_annotation*
+        Template used instead when the mark has no annotation.
+        Default: `- @{path}:L{line}`
+
 `toggle_mark`                                               *fusen-opt-toggle_mark*
     Settings for toggle mark behavior.
 
@@ -227,6 +252,16 @@ COMMANDS                                                     *fusen-commands*
 :FusenList                                                       *:FusenList*
     Show all sticky notes in quickfix list.
 
+:FusenYank [scope]                                               *:FusenYank*
+    Yank marks to the system clipboard (`+` register), formatted with the
+    configured template (see |fusen-opt-yank|). Scope is one of:
+    - `line` (default): mark at the cursor line
+    - `buffer`: marks in the current buffer
+    - `all`: all marks in the project
+
+    Requires a clipboard provider (see |clipboard|). When no provider is
+    available, a warning is shown and nothing is copied.
+
 :FusenRefresh                                                 *:FusenRefresh*
     Refresh display of all sticky notes.
 
@@ -284,6 +319,15 @@ Default mappings:
 `ml`                                                          *fusen-map-list*
     Show marks in quickfix list.
 
+`my`                                                     *fusen-map-yank-line*
+    Yank mark at cursor line to clipboard.
+
+`mY`                                                   *fusen-map-yank-buffer*
+    Yank marks in current buffer to clipboard.
+
+`mA`                                                      *fusen-map-yank-all*
+    Yank all marks in project to clipboard.
+
 ==============================================================================
 FUNCTIONS                                                   *fusen-functions*
 
@@ -315,6 +359,10 @@ require("fusen").prev_mark()                              *fusen.prev_mark()*
 
 require("fusen").list_marks()                            *fusen.list_marks()*
     Show all marks in quickfix list.
+
+require("fusen").yank_marks({scope})                      *fusen.yank_marks()*
+    Yank marks to the system clipboard. {scope} is "line" (default),
+    "buffer" or "all". See |:FusenYank|.
 
 require("fusen").refresh_marks()                      *fusen.refresh_marks()*
     Refresh display of all marks.

--- a/lua/fusen/config.lua
+++ b/lua/fusen/config.lua
@@ -17,6 +17,16 @@ M.defaults = {
     next_mark = "mn",
     prev_mark = "mp",
     list_marks = "ml",
+    yank_line = "my",
+    yank_buffer = "mY",
+    yank_all = "mA",
+  },
+
+  yank = {
+    -- Template for each mark. Placeholders: {path} {file} {line} {annotation}
+    template = '- @{path}:L{line} - "{annotation}"',
+    -- Used instead when the mark has no annotation
+    template_no_annotation = "- @{path}:L{line}",
   },
 
   toggle_mark = {

--- a/lua/fusen/init.lua
+++ b/lua/fusen/init.lua
@@ -320,6 +320,16 @@ function M.list_marks()
   ui.create_quickfix_list()
 end
 
+-- Copy marks to the system clipboard.
+-- scope: "line" (default, mark at cursor) | "buffer" | "all"
+function M.yank_marks(scope)
+  if not check_enabled() then
+    return
+  end
+
+  require("fusen.yank").yank(scope or "line")
+end
+
 function M.open_save_file()
   local save_file = config.get().save_file
   vim.cmd.edit(save_file)
@@ -360,6 +370,15 @@ local function setup_buffer_keymaps(bufnr)
   vim.keymap.set("n", keymaps.next_mark, M.next_mark, opts)
   vim.keymap.set("n", keymaps.prev_mark, M.prev_mark, opts)
   vim.keymap.set("n", keymaps.list_marks, M.list_marks, opts)
+  vim.keymap.set("n", keymaps.yank_line, function()
+    M.yank_marks("line")
+  end, opts)
+  vim.keymap.set("n", keymaps.yank_buffer, function()
+    M.yank_marks("buffer")
+  end, opts)
+  vim.keymap.set("n", keymaps.yank_all, function()
+    M.yank_marks("all")
+  end, opts)
 end
 
 function M.setup_keymaps()
@@ -435,6 +454,18 @@ function M.setup_commands()
   vim.api.nvim_create_user_command("FusenList", function()
     M.list_marks()
   end, {})
+
+  vim.api.nvim_create_user_command("FusenYank", function(cmd_opts)
+    local scope = vim.trim(cmd_opts.args)
+    M.yank_marks(scope ~= "" and scope or nil)
+  end, {
+    nargs = "?",
+    complete = function(arg_lead)
+      return vim.tbl_filter(function(scope)
+        return vim.startswith(scope, arg_lead)
+      end, require("fusen.yank").scopes)
+    end,
+  })
 
   vim.api.nvim_create_user_command("FusenRefresh", function()
     M.refresh_marks()

--- a/lua/fusen/yank.lua
+++ b/lua/fusen/yank.lua
@@ -1,0 +1,106 @@
+local M = {}
+
+-- Valid scopes, exposed for the :FusenYank completion
+M.scopes = { "line", "buffer", "all" }
+
+-- Convert an absolute path to a path relative to the current working directory.
+-- Falls back to the original path when it cannot be made relative.
+local function to_relative_path(absolute_path)
+  local relative = vim.fn.fnamemodify(absolute_path, ":.")
+  if relative == "" then
+    return absolute_path
+  end
+  return relative
+end
+
+-- Render one mark using the configured yank template.
+-- Placeholders: {path} {file} {line} {annotation}
+-- Unknown placeholders are kept as-is.
+local function render(mark, yank_config)
+  -- Marks loaded from a hand-edited save file may have a missing or null
+  -- annotation; normalize both to an empty string
+  local annotation = mark.annotation
+  if annotation == nil or annotation == vim.NIL then
+    annotation = ""
+  end
+
+  local template = annotation == "" and yank_config.template_no_annotation or yank_config.template
+
+  local values = {
+    path = to_relative_path(mark.file),
+    file = mark.file,
+    line = tostring(mark.line),
+    annotation = annotation,
+  }
+
+  return (template:gsub("{(%w+)}", function(key)
+    return values[key]
+  end))
+end
+
+-- Collect marks for the scope and render them, one line per mark.
+-- Returns nil for an invalid scope, an empty table when no marks match.
+local function collect(scope)
+  local marks = require("fusen.marks")
+
+  local scoped_marks
+  if scope == "all" then
+    scoped_marks = marks.get_marks()
+  elseif scope == "buffer" then
+    scoped_marks = marks.get_buffer_marks(vim.api.nvim_get_current_buf())
+  elseif scope == "line" then
+    local cursor_line = vim.api.nvim_win_get_cursor(0)[1]
+    scoped_marks = {}
+    for _, mark in ipairs(marks.get_buffer_marks(vim.api.nvim_get_current_buf())) do
+      if mark.line == cursor_line then
+        table.insert(scoped_marks, mark)
+      end
+    end
+  else
+    return nil
+  end
+
+  local yank_config = require("fusen.config").get().yank
+  local lines = {}
+  for _, mark in ipairs(scoped_marks) do
+    table.insert(lines, render(mark, yank_config))
+  end
+
+  return lines
+end
+
+-- Format marks as text, one rendered template per mark, joined with newlines.
+-- scope: "line" (mark at cursor) | "buffer" (current buffer) | "all" (project)
+-- Returns nil for an invalid scope, an empty string when no marks match.
+function M.get_text(scope)
+  local lines = collect(scope)
+  if not lines then
+    return nil
+  end
+  return table.concat(lines, "\n")
+end
+
+-- Copy marks to the system clipboard ("+" register).
+function M.yank(scope)
+  local lines = collect(scope)
+  if lines == nil then
+    vim.notify("Invalid scope: " .. tostring(scope) .. " (expected line, buffer or all)", vim.log.levels.ERROR)
+    return
+  end
+
+  if #lines == 0 then
+    vim.notify("No marks to yank", vim.log.levels.INFO)
+    return
+  end
+
+  -- setreg("+") fails silently without a clipboard provider; check upfront
+  if vim.fn.has("clipboard") == 0 then
+    vim.notify("No clipboard provider available; cannot yank marks", vim.log.levels.WARN)
+    return
+  end
+
+  vim.fn.setreg("+", table.concat(lines, "\n"))
+  vim.notify("Yanked " .. #lines .. " mark(s) to clipboard", vim.log.levels.INFO)
+end
+
+return M

--- a/tests/yank_spec.lua
+++ b/tests/yank_spec.lua
@@ -1,0 +1,276 @@
+describe("fusen.yank", function()
+  local yank
+  local config
+  local cwd
+  local marks_fixture
+
+  -- Store original functions
+  local original_nvim_buf_get_name
+  local original_nvim_win_get_cursor
+  local original_setreg
+  local original_has
+  local original_notify
+
+  -- Captured calls
+  local setreg_calls
+  local notify_messages
+
+  before_each(function()
+    -- Clear module cache
+    package.loaded["fusen.yank"] = nil
+    package.loaded["fusen.marks"] = nil
+    package.loaded["fusen.config"] = nil
+
+    cwd = vim.fn.getcwd()
+    marks_fixture = {}
+    setreg_calls = {}
+    notify_messages = {}
+
+    -- Mock marks module with the two queries yank depends on
+    package.loaded["fusen.marks"] = {
+      get_marks = function()
+        return marks_fixture
+      end,
+      get_buffer_marks = function(bufnr)
+        local file = vim.api.nvim_buf_get_name(bufnr)
+        local result = {}
+        for _, mark in ipairs(marks_fixture) do
+          if mark.file == file then
+            table.insert(result, mark)
+          end
+        end
+        table.sort(result, function(a, b)
+          return a.line < b.line
+        end)
+        return result
+      end,
+    }
+
+    original_nvim_buf_get_name = vim.api.nvim_buf_get_name
+    original_nvim_win_get_cursor = vim.api.nvim_win_get_cursor
+    original_setreg = vim.fn.setreg
+    original_has = vim.fn.has
+    original_notify = vim.notify
+
+    vim.fn.setreg = function(reg, text)
+      table.insert(setreg_calls, { reg = reg, text = text })
+    end
+    vim.fn.has = function(feature)
+      if feature == "clipboard" then
+        return 1
+      end
+      return original_has(feature)
+    end
+    vim.notify = function(msg)
+      table.insert(notify_messages, msg)
+    end
+
+    config = require("fusen.config")
+    config.setup({})
+
+    yank = require("fusen.yank")
+  end)
+
+  after_each(function()
+    vim.api.nvim_buf_get_name = original_nvim_buf_get_name
+    vim.api.nvim_win_get_cursor = original_nvim_win_get_cursor
+    vim.fn.setreg = original_setreg
+    vim.fn.has = original_has
+    vim.notify = original_notify
+    package.loaded["fusen.marks"] = nil
+    package.loaded["fusen.yank"] = nil
+    package.loaded["fusen.config"] = nil
+  end)
+
+  describe("get_text", function()
+    it("should format all marks with the default template", function()
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "first note" },
+        { file = cwd .. "/src/bar.lua", line = 3, annotation = "second note" },
+      }
+
+      local expected = '- @lua/foo.lua:L10 - "first note"\n- @src/bar.lua:L3 - "second note"'
+      assert.are.equal(expected, yank.get_text("all"))
+    end)
+
+    it("should use template_no_annotation for marks without annotation", function()
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 5, annotation = "" },
+      }
+
+      assert.are.equal("- @lua/foo.lua:L5", yank.get_text("all"))
+    end)
+
+    it("should treat a nil annotation as empty", function()
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 5 },
+      }
+
+      assert.are.equal("- @lua/foo.lua:L5", yank.get_text("all"))
+    end)
+
+    it("should treat a vim.NIL annotation as empty", function()
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 5, annotation = vim.NIL },
+      }
+
+      assert.are.equal("- @lua/foo.lua:L5", yank.get_text("all"))
+    end)
+
+    it("should return nil for an invalid scope", function()
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "note" },
+      }
+
+      assert.is_nil(yank.get_text("typo"))
+    end)
+
+    it("should return only current buffer marks for buffer scope", function()
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "current" },
+        { file = cwd .. "/src/bar.lua", line = 3, annotation = "other" },
+      }
+
+      vim.api.nvim_buf_get_name = function()
+        return cwd .. "/lua/foo.lua"
+      end
+
+      assert.are.equal('- @lua/foo.lua:L10 - "current"', yank.get_text("buffer"))
+    end)
+
+    it("should return only the mark at the cursor line for line scope", function()
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "at cursor" },
+        { file = cwd .. "/lua/foo.lua", line = 20, annotation = "other line" },
+      }
+
+      vim.api.nvim_buf_get_name = function()
+        return cwd .. "/lua/foo.lua"
+      end
+      vim.api.nvim_win_get_cursor = function()
+        return { 10, 0 }
+      end
+
+      assert.are.equal('- @lua/foo.lua:L10 - "at cursor"', yank.get_text("line"))
+    end)
+
+    it("should return empty string when no mark at cursor line", function()
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "note" },
+      }
+
+      vim.api.nvim_buf_get_name = function()
+        return cwd .. "/lua/foo.lua"
+      end
+      vim.api.nvim_win_get_cursor = function()
+        return { 5, 0 }
+      end
+
+      assert.are.equal("", yank.get_text("line"))
+    end)
+
+    it("should apply a custom template from config", function()
+      config.setup({
+        yank = {
+          template = "{file}:{line} {annotation}",
+        },
+      })
+
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "note" },
+      }
+
+      assert.are.equal(cwd .. "/lua/foo.lua:10 note", yank.get_text("all"))
+    end)
+
+    it("should keep unknown placeholders as-is", function()
+      config.setup({
+        yank = {
+          template = "{path} {unknown} {annotation}",
+        },
+      })
+
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "note" },
+      }
+
+      assert.are.equal("lua/foo.lua {unknown} note", yank.get_text("all"))
+    end)
+  end)
+
+  describe("yank", function()
+    it("should copy marks to the + register and notify the count", function()
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "first" },
+        { file = cwd .. "/src/bar.lua", line = 3, annotation = "second" },
+      }
+
+      yank.yank("all")
+
+      assert.are.equal(1, #setreg_calls)
+      assert.are.equal("+", setreg_calls[1].reg)
+      assert.are.equal('- @lua/foo.lua:L10 - "first"\n- @src/bar.lua:L3 - "second"', setreg_calls[1].text)
+      assert.are.equal("Yanked 2 mark(s) to clipboard", notify_messages[1])
+    end)
+
+    it("should count marks correctly with a multi-line template", function()
+      config.setup({
+        yank = {
+          template = "{path}:{line}\n  {annotation}",
+        },
+      })
+
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "first" },
+        { file = cwd .. "/src/bar.lua", line = 3, annotation = "second" },
+      }
+
+      yank.yank("all")
+
+      assert.are.equal("Yanked 2 mark(s) to clipboard", notify_messages[1])
+    end)
+
+    it("should not touch the register when there are no marks", function()
+      vim.api.nvim_buf_get_name = function()
+        return cwd .. "/lua/foo.lua"
+      end
+      vim.api.nvim_win_get_cursor = function()
+        return { 1, 0 }
+      end
+
+      yank.yank("line")
+
+      assert.are.equal(0, #setreg_calls)
+      assert.are.equal("No marks to yank", notify_messages[1])
+    end)
+
+    it("should reject an invalid scope", function()
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "note" },
+      }
+
+      yank.yank("typo")
+
+      assert.are.equal(0, #setreg_calls)
+      assert.is_truthy(notify_messages[1]:match("Invalid scope"))
+    end)
+
+    it("should warn instead of reporting success when no clipboard provider exists", function()
+      vim.fn.has = function(feature)
+        if feature == "clipboard" then
+          return 0
+        end
+        return original_has(feature)
+      end
+
+      marks_fixture = {
+        { file = cwd .. "/lua/foo.lua", line = 10, annotation = "note" },
+      }
+
+      yank.yank("all")
+
+      assert.are.equal(0, #setreg_calls)
+      assert.is_truthy(notify_messages[1]:match("No clipboard provider"))
+    end)
+  end)
+end)


### PR DESCRIPTION
## 🤖 Turn your sticky notes into AI prompts

You read code, you leave notes — *"this needs refactoring"*, *"why is this async?"*, *"fix this edge case"*.

Until now those notes stayed in your editor. This PR lets you hand **all of them to your AI assistant in one keystroke**.

<img width="3448" height="1612" alt="2026-07-11_22 39 39" src="https://github.com/user-attachments/assets/5b3d005e-8e3d-4121-be9a-18bb6037bde9" />

## What's new

Press `mA` and every sticky note in your project lands in your clipboard, formatted so AI coding tools (Claude Code, Copilot CLI, Cursor, ...) can jump straight to the referenced lines:

```
- @lua/fusen/config.lua:L12 - "TODO: check for conflicts with built-in marks"
- @lua/fusen/config.lua:L27 - "Can we support multi-line templates?"
- @lua/fusen/config.lua:L29 - "NOTE: keep in sync with README examples"
```

Paste it into your AI chat and the `@path` references let the assistant open the files itself — no copy-pasting code around.

### Commands & keymaps

| Key | Command | Scope |
|-----|---------|-------|
| `my` | `:FusenYank` (or `:FusenYank line`) | mark at the cursor line |
| `mY` | `:FusenYank buffer` | current buffer |
| `mA` | `:FusenYank all` | whole project |

### Customizable template

Not into the default format? Make your own:

```lua
yank = {
  template = '- @{path}:L{line} - "{annotation}"',
  template_no_annotation = "- @{path}:L{line}",
}
```

Placeholders: `{path}` (cwd-relative), `{file}` (absolute), `{line}`, `{annotation}` — e.g. compiler-style `"{path}:{line} {annotation}"` works too.

## Why

AI coding assistants are becoming part of everyday development. fusen.nvim's sticky notes are a natural fit for that workflow: annotate the exact lines you want the AI to look at *while you read*, then ship the whole list in one go. This PR gives fusen that bridge — with **zero new dependencies** and no changes to existing behavior.

## Implementation notes

- New self-contained `lua/fusen/yank.lua` module; existing behavior untouched
- Requires a clipboard provider (`:help clipboard`); shows a warning instead of failing silently when none is available
- Robust against hand-edited save files (missing / `null` annotations)
- 15 new unit tests (103 passing in total)
